### PR TITLE
Changed index to multi index in aggregate returns function

### DIFF
--- a/qrisk/stats.py
+++ b/qrisk/stats.py
@@ -143,15 +143,17 @@ def aggregate_returns(returns, convert_to):
         return cum_returns(x)[-1]
 
     if convert_to == WEEKLY:
-        return returns.resample('W', how={'Agg': cumulate_returns})
+        grouping = [lambda x: x.year, lambda x: x.isocalendar()[1]]
     elif convert_to == MONTHLY:
-        return returns.resample('M', how={'Agg': cumulate_returns})
+        grouping = [lambda x: x.year, lambda x: x.month]
     elif convert_to == YEARLY:
-        return returns.resample('A', how={'Agg': cumulate_returns})
+        grouping = [lambda x: x.year]
     else:
-        ValueError(
+        raise ValueError(
             'convert_to must be {}, {} or {}'.format(WEEKLY, MONTHLY, YEARLY)
         )
+
+    return returns.groupby(grouping).apply(cumulate_returns)
 
 
 def max_drawdown(returns):
@@ -504,7 +506,7 @@ def information_ratio(returns, factor_returns):
     ----------
     returns : pd.Series or pd.DataFrame
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`qrisk.stats.cum_returns`.
+        - See full explanation in :func:`~qrisk.stats.cum_returns`.
     factor_returns: float / series
         Benchmark return to compare returns against.
 
@@ -600,7 +602,7 @@ def beta(returns, factor_returns, risk_free=0.0):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`qrisk.stats.cum_returns`.
+        - See full explanation in :func:`~qrisk.stats.cum_returns`.
     factor_returns : pd.Series
          Daily noncumulative returns of the factor to which beta is
          computed. Usually a benchmark such as the market.

--- a/qrisk/tests/test_stats.py
+++ b/qrisk/tests/test_stats.py
@@ -104,7 +104,7 @@ class TestStats(TestCase):
         (monthly_returns, qrisk.YEARLY, [0.038931091700480147])
     ])
     def test_aggregate_returns(self, returns, convert_to, expected):
-        returns = list(qrisk.aggregate_returns(returns, convert_to)['Agg'])
+        returns = qrisk.aggregate_returns(returns, convert_to).values.tolist()
         for i, v in enumerate(returns):
             assert_almost_equal(
                 v,


### PR DESCRIPTION
Some tear sheet graphs in pyfolio require a multi index dataframe. Instead of returning a list of dates as an index, return a multi index that separates those dates by year, week number, month.

Aggregation function will use `Series.groupby` instead of `Series.resample`, which is currently deprecated.